### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ CFLAGS_NEXTCLIP = -Iinclude
 NEXTCLIP_OBJ = obj/nextclip.o obj/hash_table.o obj/hash_value.o obj/logger.o obj/binary_kmer.o obj/element.o
 
 all:remove_objects $(NEXTCLIP_OBJ)
-	mkdir -p $(BIN); $(CC) -lm $(OPT) -o $(BIN)/nextclip $(NEXTCLIP_OBJ)
+	mkdir -p $(BIN); $(CC) $(OPT) -o $(BIN)/nextclip $(NEXTCLIP_OBJ) -lm
 
 clean:
 	rm obj/*


### PR DESCRIPTION
original ordering of math library was causing "undefined reference" error with log, ceil and pow in the linker with gcc 4.6.
