### PR TITLE
Add support for pre-Casava 1.8 illumina headers

### DIFF
--- a/src/nextclip.c
+++ b/src/nextclip.c
@@ -1030,6 +1030,9 @@ void check_read_ids(MPStats* stats, FastQRead* read_one, FastQRead* read_two)
         
         if (read_one->read_header[p] <= ' ') {
             break;
+        }
+        else if (read_one->read_header[p] == '/') {
+            break;
         } else {
             p++;
         }


### PR DESCRIPTION
I would like to add support for older fastq `@` lines
http://en.wikipedia.org/wiki/FASTQ_format#Illumina_sequence_identifiers

Before Casava 1.8, the nth member of a pair-end or mate pair read was encoded following a slash: e.g. 

```
@HWUSI-EAS100R:6:73:941:1973#0/1
```

After Casava 1.8, this follows a space, e.g. 

```
@EAS139:136:FC706VJ:2:2104:15343:197393 1:Y:18:ATCACG
```
