### PR TITLE
Removed MAC definitions form Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,6 @@
 BIN = bin
 MAXK = 63
 
-ifdef MAC
-define n
-
-
-endef
-$(warning $n$nNOTE On Mac OS X, you must compile using GCC. If you have not already done so, please change the line CC= in this Makefile to point to your GCC compiler. $nThis must be a full path, as Apple aliases gcc to point to it's own compiler.$n)
-
-# Change the following to point to your GCC binary
-CC=gcc
-
-# On my MAC, I use CC=~/gcc/bin/gcc
-
-# On older versions of XCode, it was necessary to include the following
-#MACFLAG = -fnested-functions -L/opt/local/lib/ 
-endif
-
 ifeq ($(MAXK),31)
    BITFIELDS = 1
 endif
@@ -33,7 +17,7 @@ ifeq ($(MAXK),127)
    BITFIELDS = 4
 endif
 
-OPT	= $(ARCH) $(MACFLAG) -Wall -O3 -DNUMBER_OF_BITFIELDS_IN_BINARY_KMER=$(BITFIELDS) -pthread -g
+OPT	= $(ARCH) -Wall -O3 -DNUMBER_OF_BITFIELDS_IN_BINARY_KMER=$(BITFIELDS) -pthread -g
 
 CFLAGS_NEXTCLIP = -Iinclude
 


### PR DESCRIPTION
These are not needed anymore if you set CC properly in the environment.